### PR TITLE
wUSDM/N-01

### DIFF
--- a/contracts/wUSDM.sol
+++ b/contracts/wUSDM.sol
@@ -184,5 +184,5 @@ contract wUSDM is
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[49] private __gap;
+    uint256[48] private __gap;
 }


### PR DESCRIPTION
The [wUSDM](https://github.com/mountainprotocol/tokens/blob/97f99eeeb8f94540b8a33ffd69026234398a2a8e/contracts/wUSDM.sol) contract implements the [__gap](https://github.com/mountainprotocol/tokens/blob/97f99eeeb8f94540b8a33ffd69026234398a2a8e/contracts/wUSDM.sol#L187) storage variable to reserve space for adding new state variables in the future without compromising storage compatibility with existing deployments. The convention used by the OpenZeppelin contracts is to use a [__gap array with the size of 50](https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps) subtracted by the number of the used storage slots. wUSDM uses two storage slots for the [USDM variable](https://github.com/mountainprotocol/tokens/blob/97f99eeeb8f94540b8a33ffd69026234398a2a8e/contracts/wUSDM.sol#L35) and [_nonces mapping](https://github.com/mountainprotocol/tokens/blob/97f99eeeb8f94540b8a33ffd69026234398a2a8e/contracts/wUSDM.sol#L38) but the size of the [__gap array is 49](https://github.com/mountainprotocol/tokens/blob/97f99eeeb8f94540b8a33ffd69026234398a2a8e/contracts/wUSDM.sol#L187).

Consider changing the size of the __gap array to 48.