### PR TITLE
Fix hooks overriding styleguide

### DIFF
--- a/contracts/wUSDM.sol
+++ b/contracts/wUSDM.sol
@@ -106,7 +106,7 @@ contract wUSDM is
      *
      * Note: If either `from` or `to` are blocked, or the contract is paused, it reverts the transaction.
      */
-    function _beforeTokenTransfer(address from, address /* to */, uint256 /* amount */) internal view override {
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
         // Each blocklist check is an SLOAD, which is gas intensive.
         // We only block sender not receiver, so we don't tax every user
         if (USDM.isBlocked(from)) {
@@ -119,6 +119,8 @@ contract wUSDM is
         if (paused()) {
             revert wUSDMPausedTransfers();
         }
+
+        super._beforeTokenTransfer(from, to, amount);
     }
 
     /**


### PR DESCRIPTION
The [wUSDM](https://github.com/mountainprotocol/tokens/blob/97f99eeeb8f94540b8a33ffd69026234398a2a8e/contracts/wUSDM.sol) contract that overrides the [_beforeTokenTransfer](https://github.com/mountainprotocol/tokens/blob/97f99eeeb8f94540b8a33ffd69026234398a2a8e/contracts/wUSDM.sol#L109) hook function does not follow the [guidelines on hooks overriding](https://docs.openzeppelin.com/contracts/4.x/extending-contracts#rules_of_hooks). The overridden hook is not marked with the virtual keyword and does not call the parent's hook using super.

Consider making the _beforeTokenTransfer hook function virtual and adding a call to the parent's hook.